### PR TITLE
Allow Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Summary

Bumps `requires-python` from `>=3.11,<3.14` to `>=3.11,<3.15` so chemap can be installed on Python 3.14.

chemap's runtime dependencies all ship Python 3.14 wheels:
- `numba 0.65.1` / `llvmlite 0.47.0`
- `numpy 2.x`, `scipy 1.16+`, `pandas 2.3+` / `3.x`
- `rdkit 2025.9+`
- `scikit-fingerprints 2.0+`
- `matplotlib 3.10+`

So the existing `<3.14` cap looks stale rather than a real constraint.

## Motivation

Unblocks matchms/matchms#901, which adds Python 3.14 support to matchms on the `development` branch. Right now `development`'s CI fails on Python 3.14 because chemap refuses to install:

```
chemap requires Python <3.14,>=3.11, so it will not be installable for Python >=3.14,<3.15
```

## Test plan

- [ ] CI passes on Python 3.11, 3.12, 3.13, and 3.14